### PR TITLE
refer to the API schemas in the json schema for CoO

### DIFF
--- a/docs/certificates/CertificateOfOrigin-schema.json
+++ b/docs/certificates/CertificateOfOrigin-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://edi3.org/specs/edi3-regulatory/develop/certificates/CertificateOfOrigin-schema.json",
+  "description": "The json schema for CertificateOfOrigin",
+  "type": "object",
+  "properties": {
+    "certificateOfOrigin": {
+      "$ref": "edi3.org/specs/edi3-regulatory/develop/certificates/CertificateOfOrigin.json#/components/schemas/CertificateOfOrigin"
+    }
+  },
+  "required": [
+    "certificateOfOrigin"
+  ]
+}

--- a/docs/certificates/CertificateOfOrigin.json
+++ b/docs/certificates/CertificateOfOrigin.json
@@ -1,16 +1,181 @@
 {
-    "schema": {
-        "model": "CertificateOfOrigin",
-        "type": "object",
-        "properties": {
-            "certificatesOfOrigin": {
-                "$ref": "#/definitions/CertificateOfOrigin"
+    "openapi": "3.0.0",
+    "info": {
+        "description": "",
+        "title": "CertificateOfOrigin",
+        "version": ""
+    },
+    "servers": [],
+    "paths": {
+        "/CertificatesOfOrigin": {
+            "get": {
+                "tags": [
+                    "CertificatesOfOrigin"
+                ],
+                "description": "Get a list of CertificateOfOrigin",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/CertificateOfOrigin"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                }
             },
-            "certification": {
-                "$ref": "#/definitions/Document_Authentication"
+            "post": {
+                "tags": [
+                    "CertificatesOfOrigin"
+                ],
+                "description": "Create a new CertificateOfOrigin",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CertificateOfOrigin"
+                            }
+                        }
+                    },
+                    "description": "",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CertificateOfOrigin"
+                                }
+                            }
+                        },
+                        "description": "Created"
+                    }
+                }
             }
         },
-        "definitions": {
+        "/CertificatesOfOrigin/{id}": {
+            "get": {
+                "tags": [
+                    "CertificatesOfOrigin"
+                ],
+                "description": "Get single CertificateOfOrigin by id",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "missing description",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CertificateOfOrigin"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "CertificatesOfOrigin"
+                ],
+                "description": "Update an existing CertificateOfOrigin",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "missing description",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CertificateOfOrigin"
+                            }
+                        }
+                    },
+                    "description": "",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CertificateOfOrigin"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/CertificatesOfOrigin/{id}/Certification": {
+            "post": {
+                "tags": [
+                    "CertificatesOfOrigin"
+                ],
+                "description": "Create a new CertificateOfOrigin",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "missing description",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DocumentAuthentication"
+                            }
+                        }
+                    },
+                    "description": "",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DocumentAuthentication"
+                                }
+                            }
+                        },
+                        "description": "Created"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
             "CertificateOfOrigin": {
                 "description": "",
                 "type": "object",
@@ -33,14 +198,14 @@
                                 "description": ""
                             },
                             {
-                                "$ref": "#/definitions/SupplyChainConsignment"
+                                "$ref": "#/components/schemas/SupplyChainConsignment"
                             }
                         ]
                     }
                 },
                 "allOf": [
                     {
-                        "$ref": "#/definitions/ExchangedDocument"
+                        "$ref": "#/components/schemas/ExchangedDocument"
                     },
                     {
                         "type": "object"
@@ -104,7 +269,7 @@
                                 "description": "A binary file attached to this exchanged document."
                             },
                             {
-                                "$ref": "#/definitions/SpecifiedBinaryFile"
+                                "$ref": "#/components/schemas/SpecifiedBinaryFile"
                             }
                         ]
                     },
@@ -114,7 +279,7 @@
                                 "description": "The first or primary signature that authenticates this exchanged document."
                             },
                             {
-                                "$ref": "#/definitions/DocumentAuthentication"
+                                "$ref": "#/components/schemas/DocumentAuthentication"
                             }
                         ]
                     },
@@ -124,7 +289,7 @@
                                 "description": "The location where this exchanged document has been issued."
                             },
                             {
-                                "$ref": "#/definitions/LogisticsLocation"
+                                "$ref": "#/components/schemas/LogisticsLocation"
                             }
                         ]
                     },
@@ -134,7 +299,7 @@
                                 "description": "The party that issues this exchanged document."
                             },
                             {
-                                "$ref": "#/definitions/TradeParty"
+                                "$ref": "#/components/schemas/TradeParty"
                             }
                         ]
                     },
@@ -144,7 +309,7 @@
                                 "description": "The second signature, also known as the first counter signature, that has been authenticated on this exchanged document indicating where appropriate the authentication party."
                             },
                             {
-                                "$ref": "#/definitions/DocumentAuthentication"
+                                "$ref": "#/components/schemas/DocumentAuthentication"
                             }
                         ]
                     }
@@ -221,7 +386,7 @@
                                 "description": "A departure event during this logistics transport movement."
                             },
                             {
-                                "$ref": "#/definitions/TransportEvent"
+                                "$ref": "#/components/schemas/TransportEvent"
                             }
                         ]
                     },
@@ -231,7 +396,7 @@
                                 "description": "The means of transport used for this logistics transport movement."
                             },
                             {
-                                "$ref": "#/definitions/LogisticsTransportMeans"
+                                "$ref": "#/components/schemas/LogisticsTransportMeans"
                             }
                         ]
                     }
@@ -268,7 +433,7 @@
                     "attachedBinaryFile": {
                         "allOf": [
                             {
-                                "$ref": "#/definitions/SpecifiedBinaryFileIds"
+                                "$ref": "#/components/schemas/SpecifiedBinaryFileIds"
                             },
                             {
                                 "type": "object"
@@ -335,7 +500,7 @@
                                 "description": "The export country for this supply chain consignment."
                             },
                             {
-                                "$ref": "#/definitions/TradeCountry"
+                                "$ref": "#/components/schemas/TradeCountry"
                             }
                         ]
                     },
@@ -345,7 +510,7 @@
                                 "description": "The party who exports this supply chain consignment."
                             },
                             {
-                                "$ref": "#/definitions/TradeParty"
+                                "$ref": "#/components/schemas/TradeParty"
                             }
                         ]
                     },
@@ -355,7 +520,7 @@
                                 "description": "The import country for this supply chain consignment."
                             },
                             {
-                                "$ref": "#/definitions/TradeCountry"
+                                "$ref": "#/components/schemas/TradeCountry"
                             }
                         ]
                     },
@@ -365,13 +530,13 @@
                                 "description": "The party who imports this supply chain consignment."
                             },
                             {
-                                "$ref": "#/definitions/TradeParty"
+                                "$ref": "#/components/schemas/TradeParty"
                             }
                         ]
                     },
                     "includedConsignmentItems": {
                         "items": {
-                            "$ref": "#/definitions/SupplyChainConsignmentItem"
+                            "$ref": "#/components/schemas/SupplyChainConsignmentItem"
                         },
                         "type": "array",
                         "description": "A consignment item included in this supply chain consignment."
@@ -382,7 +547,7 @@
                                 "description": "The baseport location at which this supply chain consignment is to be loaded on a means of transport according to the transport contract."
                             },
                             {
-                                "$ref": "#/definitions/LogisticsLocation"
+                                "$ref": "#/components/schemas/LogisticsLocation"
                             }
                         ]
                     },
@@ -392,13 +557,13 @@
                                 "description": "A main carriage logistics transport movement for this supply chain consignment."
                             },
                             {
-                                "$ref": "#/definitions/LogisticsTransportMovement"
+                                "$ref": "#/components/schemas/LogisticsTransportMovement"
                             }
                         ]
                     },
                     "transportPackages": {
                         "items": {
-                            "$ref": "#/definitions/LogisticsPackage"
+                            "$ref": "#/components/schemas/LogisticsPackage"
                         },
                         "type": "array",
                         "description": "Transport packages for this supply chain consignment."
@@ -409,7 +574,7 @@
                                 "description": "The baseport location at which this supply chain consignment is to be unloaded from a means of transport according to the transport contract."
                             },
                             {
-                                "$ref": "#/definitions/LogisticsLocation"
+                                "$ref": "#/components/schemas/LogisticsLocation"
                             }
                         ]
                     }
@@ -434,7 +599,7 @@
                                 "description": "A cross-border regulatory procedure applicable to this supply chain consignment item."
                             },
                             {
-                                "$ref": "#/definitions/CrossBorderRegulatoryProcedure"
+                                "$ref": "#/components/schemas/CrossBorderRegulatoryProcedure"
                             }
                         ]
                     },
@@ -444,13 +609,13 @@
                                 "description": "The party which manufactured this supply chain consignment item."
                             },
                             {
-                                "$ref": "#/definitions/TradeParty"
+                                "$ref": "#/components/schemas/TradeParty"
                             }
                         ]
                     },
                     "tradeLineItems": {
                         "items": {
-                            "$ref": "#/definitions/SupplyChainTradeLineItem"
+                            "$ref": "#/components/schemas/SupplyChainTradeLineItem"
                         },
                         "type": "array",
                         "description": "A trade line item included in this supply chain consignment item."
@@ -471,7 +636,7 @@
                                 "description": "A document referenced for this supply chain trade line item."
                             },
                             {
-                                "$ref": "#/definitions/ReferencedDocument"
+                                "$ref": "#/components/schemas/ReferencedDocument"
                             }
                         ]
                     },
@@ -481,7 +646,7 @@
                                 "description": "The product specified for this supply chain trade line item."
                             },
                             {
-                                "$ref": "#/definitions/TradeProduct"
+                                "$ref": "#/components/schemas/TradeProduct"
                             }
                         ]
                     }
@@ -565,7 +730,7 @@
                                 "description": "The postal address for this trade party."
                             },
                             {
-                                "$ref": "#/definitions/TradeAddress"
+                                "$ref": "#/components/schemas/TradeAddress"
                             }
                         ]
                     }
@@ -590,7 +755,7 @@
                                 "description": "A product classification designated for this trade product."
                             },
                             {
-                                "$ref": "#/definitions/ProductClassification"
+                                "$ref": "#/components/schemas/ProductClassification"
                             }
                         ]
                     },
@@ -600,7 +765,7 @@
                                 "description": "A country of origin for this trade product."
                             },
                             {
-                                "$ref": "#/definitions/TradeCountry"
+                                "$ref": "#/components/schemas/TradeCountry"
                             }
                         ]
                     }

--- a/docs/certificates/CertificateOfOrigin.sampleFull.json
+++ b/docs/certificates/CertificateOfOrigin.sampleFull.json
@@ -1,226 +1,230 @@
 {
-  "iD": "wfa.org.au:coo:WBC208897",
-  "issueDateTime": "2020-06-03T00:46:34Z",
-  "name": "CHAFTA Certificate of Origin",
-  "attachedFile": {
-    "uRI": "https://wfa.org.au/filestore/",
-    "encodingCode": "base64",
-    "mIMECode": "application/pdf",
-    "size": "12600"
-  },
-  "firstSignatoryAuthentication": {
-    "signature": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJIUzI1NiJ9..5rPBT_XW-x7mjc1ubf4WwW1iV2YJyc4CCFxORIEaAEk",
-    "actualDateTime": "2020-05-29T09:46:Z",
-    "statement": "The undersigned hereby declares that the above-stated information is correct and that the goods exported to [importer] comply with the origin requirements specified in the China-Australia Free Trade Agreement."
-  },
-    "secondSignatoryAuthentication": {
-    "signature": "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-    "actualDateTime": "2020-06-03T03:50",
-    "statement": "On the basis of the control carried out, it is hereby certified that the information herein is correct and that the described goods comply with the origin requirements of the China-Australia Free Trade Agreement."
-  }
-  "issueLocation": {
-    "iD": "AUADL",
-    "name": "Adelaide"
-  },
-  "issuer": {
-    "iD": "wfa.org.au",
-    "name": "Australian Grape and Wine Incorporated",
-    "postalAddress": {
-      "line1": "Level 1, Industry Offcies",
-      "line2": "Botanic Road",
-      "cityName": "Adelaide",
-      "postcode": "5000",
-      "countrySubDivisionName": "SA",
-      "countryCode": "AU"
-    }
-  },
-  "status": "issued",
-  "isPreferential": true,
-  "freeTradeAgreement": "CHAFTA",
-  "supplyChainConsignment": {
-    "iD": "dbschenker.com:hawb:DBS626578",
-    "information": "6 pallets of fine wine, please store below 20 DegC",
-    "exportCountry": {
-      "code": "AU"
+  "certificateOfOrigin": {
+    "iD": "wfa.org.au:coo:WBC208897",
+    "issueDateTime": "2020-06-03T00:46:34Z",
+    "name": "CHAFTA Certificate of Origin",
+    "attachedFile": {
+      "uRI": "https://wfa.org.au/filestore/",
+      "encodingCode": "base64",
+      "mIMECode": "application/pdf",
+      "size": "12600"
     },
-    "exporter": {
-      "iD": "abr.gov.au:abn:55004094599",
-      "name": "TREASURY WINE ESTATES VINTNERS LIMITED",
+    "firstSignatoryAuthentication": {
+      "signature": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJIUzI1NiJ9..5rPBT_XW-x7mjc1ubf4WwW1iV2YJyc4CCFxORIEaAEk",
+      "actualDateTime": "2020-05-29T09:46:34Z",
+      "statement": "The undersigned hereby declares that the above-stated information is correct and that the goods exported to [importer] comply with the origin requirements specified in the China-Australia Free Trade Agreement."
+    },
+    "secondSignatoryAuthentication": {
+      "signature": "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+      "actualDateTime": "2020-06-03T03:50:45Z",
+      "statement": "On the basis of the control carried out, it is hereby certified that the information herein is correct and that the described goods comply with the origin requirements of the China-Australia Free Trade Agreement."
+    },
+    "issueLocation": {
+      "iD": "loc:AUADL",
+      "name": "Adelaide"
+    },
+    "issuer": {
+      "iD": "id:wfa.org.au",
+      "name": "Australian Grape and Wine Incorporated",
       "postalAddress": {
-        "line1": "161 Collins Street",
-        "cityName": "Melbourne",
-        "postcode": "3000",
-        "countrySubDivisionName": "VIC",
+        "line1": "Level 1, Industry Offcies",
+        "line2": "Botanic Road",
+        "cityName": "Adelaide",
+        "postcode": "5000",
+        "countrySubDivisionName": "SA",
         "countryCode": "AU"
       }
     },
-    "importCountry": {
-      "code": "CN"
-    },
-    "importer": {
-      "iD": "emw-wines.com",
-      "name": "East meets west fine wines",
-      "postalAddress": {
-        "line1": "Room 202, Man Po International Business Center",
-        "line2": "No. 664 Xin Hua Rd, Changning District",
-        "cityName": "Shanghai",
-        "postcode": "200052",
-        "countryCode": "CN"
-      }
-    },
-    "includedConsignmentItems": [
-      {
-        "iD": "penfolds.com:shipment:4738291",
-        "information": "2 pallets (80 cases) Bin23 Pinot and 2 pallets (80 cases) Bin 28 Shiraz",
-        "crossBorderRegulatoryProcedure": {
-          "originCriteriaText": "2204.21"
-        },
-        "manufacturer": {
-          "iD": "penfolds.com",
-          "name": "Penfolds wine",
-          "postalAddress": {
-            "line1": "Penfolds vineyard",
-            "cityName": "Bordertown",
-            "postcode": "5268",
-            "countrySubDivisionName": "SA",
-            "countryCode": "AU"
-          }
-        },
-        "tradeLineItems": [
-          {
-            "sequenceNumber":1,
-            "invoiceReference": {
-              "iD": "tweglobal.com:invoice:1122345",
-              "formattedIssueDateTime":"2020-06-02T14:30Z",
-              "attachedBinaryFile": {
-                "uRI": "https://docs.tweglobal.com/8c624a35-9497-41fb-a548-cb5cf43bac21.pdf"
-              }
-            },
-            "tradeProduct": {
-              "iD": "gs1.org:gtin:9325814006194",
-              "description": "Bin 23 Pinot Noir 2018",
-              "harmonisedTariffCode": {
-                "classCode": "2204.21",
-                "className": "Wine of fresh grapes, including fortified wines"
-              },
-              "originCountry": {
-                "code": "AU",
-              }
+    "status": "issued",
+    "isPreferential": true,
+    "freeTradeAgreement": "CHAFTA",
+    "supplyChainConsignment": {
+      "iD": "dbschenker.com:hawb:DBS626578",
+      "information": "6 pallets of fine wine, please store below 20 DegC",
+      "exportCountry": {
+        "code": "AU"
+      },
+      "exporter": {
+        "iD": "abr.gov.au:abn:55004094599",
+        "name": "TREASURY WINE ESTATES VINTNERS LIMITED",
+        "postalAddress": {
+          "line1": "161 Collins Street",
+          "cityName": "Melbourne",
+          "postcode": "3000",
+          "countrySubDivisionName": "VIC",
+          "countryCode": "AU"
+        }
+      },
+      "importCountry": {
+        "code": "CN"
+      },
+      "importer": {
+        "iD": "id:emw-wines.com",
+        "name": "East meets west fine wines",
+        "postalAddress": {
+          "line1": "Room 202, Man Po International Business Center",
+          "line2": "No. 664 Xin Hua Rd, Changning District",
+          "cityName": "Shanghai",
+          "postcode": "200052",
+          "countryCode": "CN"
+        }
+      },
+      "includedConsignmentItems": [
+        {
+          "iD": "penfolds.com:shipment:4738291",
+          "information": "2 pallets (80 cases) Bin23 Pinot and 2 pallets (80 cases) Bin 28 Shiraz",
+          "crossBorderRegulatoryProcedure": {
+            "originCriteriaText": "2204.21"
+          },
+          "manufacturer": {
+            "iD": "id:penfolds.com",
+            "name": "Penfolds wine",
+            "postalAddress": {
+              "line1": "Penfolds vineyard",
+              "cityName": "Bordertown",
+              "postcode": "5268",
+              "countrySubDivisionName": "SA",
+              "countryCode": "AU"
             }
           },
-          {
-            "sequenceNumber":2,
-            "invoiceReference": {
-              "iD": "tweglobal.com:invoice:1122345",
-              "formattedIssueDateTime":"2020-06-02T14:30Z",
-              "attachedBinaryFile": {
-                "uRI": "https://docs.tweglobal.com/8c624a35-9497-41fb-a548-cb5cf43bac21.pdf"
+          "tradeLineItems": [
+            {
+              "sequenceNumber": 1,
+              "invoiceReference": {
+                "iD": "tweglobal.com:invoice:1122345",
+                "formattedIssueDateTime": "2020-06-02T14:30:00Z",
+                "attachedBinaryFile": {
+                  "uRI": "https://docs.tweglobal.com/8c624a35-9497-41fb-a548-cb5cf43bac21.pdf"
+                }
+              },
+              "tradeProduct": {
+                "iD": "gs1.org:gtin:9325814006194",
+                "description": "Bin 23 Pinot Noir 2018",
+                "harmonisedTariffCode": {
+                  "classCode": "2204.21",
+                  "className": "Wine of fresh grapes, including fortified wines"
+                },
+                "originCountry": {
+                  "code": "AU"
+                }
               }
             },
-            "tradeProduct": {
-              "iD": "gs1.org:gtin:9325814007320",
-              "description": "Kalimna Bin 28 Shiraz 2017",
-              "harmonisedTariffCode": {
-                "classCode": "2204.21",
-                "className": "Wine of fresh grapes, including fortified wines"
+            {
+              "sequenceNumber": 2,
+              "invoiceReference": {
+                "iD": "tweglobal.com:invoice:1122345",
+                "formattedIssueDateTime": "2020-06-02T14:30:00Z",
+                "attachedBinaryFile": {
+                  "uRI": "https://docs.tweglobal.com/8c624a35-9497-41fb-a548-cb5cf43bac21.pdf"
+                }
               },
-              "originCountry": {
-                "code": "AU",
+              "tradeProduct": {
+                "iD": "gs1.org:gtin:9325814007320",
+                "description": "Kalimna Bin 28 Shiraz 2017",
+                "harmonisedTariffCode": {
+                  "classCode": "2204.21",
+                  "className": "Wine of fresh grapes, including fortified wines"
+                },
+                "originCountry": {
+                  "code": "AU"
+                }
               }
             }
-          }
-        ]
-      },
-      {
-        "iD": "lindemans.com:shipment:228764",
-        "information": "2 pallets (80 cases) Limestone Ridge Shiraz red wine",
-        "crossBorderRegulatoryProcedure": {
-          "originCriteriaText": "PSR"
+          ]
         },
-        "manufacturer": {
-          "iD": "lindemans.com",
-          "name": "Lindemans wine",
-          "postalAddress": {
-            "line1": "44 Johns way",
-            "cityName": "Red Cliffs",
-            "postcode": "3496",
-            "countrySubDivisionName": "VIC",
-            "countryCode": "AU"
-          }
-        },
-        "tradeLineItems": [{
-          "sequenceNumber":1,
-          "invoiceReference": {
-            "iD": "tweglobal.com:invoice:8877654",
-            "formattedIssueDateTime":"2020-06-05T11:30Z",
-            "attachedBinaryFile": {
-              "uRI": "https://docs.tweglobal.com/03e3754c-906d-4f6d-a592-67447c9119e9.pdf"
+        {
+          "iD": "lindemans.com:shipment:228764",
+          "information": "2 pallets (80 cases) Limestone Ridge Shiraz red wine",
+          "crossBorderRegulatoryProcedure": {
+            "originCriteriaText": "PSR"
+          },
+          "manufacturer": {
+            "iD": "id:lindemans.com",
+            "name": "Lindemans wine",
+            "postalAddress": {
+              "line1": "44 Johns way",
+              "cityName": "Red Cliffs",
+              "postcode": "3496",
+              "countrySubDivisionName": "VIC",
+              "countryCode": "AU"
             }
           },
-          "tradeProduct": {
-            "iD": "gs1.org:gtin:4088700053621",
-            "description": "Coonawarra Trio Limestone Ridge Shiraz Cabernet 2013",
-            "harmonisedTariffCode": {
-              "classCode": "2204.21",
-              "className": "Wine of fresh grapes, including fortified wines"
-            },
-            "originCountry": {
-              "code": "AU",
+          "tradeLineItems": [
+            {
+              "sequenceNumber": 1,
+              "invoiceReference": {
+                "iD": "tweglobal.com:invoice:8877654",
+                "formattedIssueDateTime": "2020-06-05T11:30:00Z",
+                "attachedBinaryFile": {
+                  "uRI": "https://docs.tweglobal.com/03e3754c-906d-4f6d-a592-67447c9119e9.pdf"
+                }
+              },
+              "tradeProduct": {
+                "iD": "gs1.org:gtin:4088700053621",
+                "description": "Coonawarra Trio Limestone Ridge Shiraz Cabernet 2013",
+                "harmonisedTariffCode": {
+                  "classCode": "2204.21",
+                  "className": "Wine of fresh grapes, including fortified wines"
+                },
+                "originCountry": {
+                  "code": "AU"
+                }
+              }
             }
-          }
-        ]
+          ]
+        }
+      ],
+      "loadingBaseportLocation": {
+        "iD": "loc:AUMEL",
+        "name": "Melbourne"
+      },
+      "mainCarriageTransportMovement": {
+        "iD": "iata.org:CX104",
+        "information": "Cathay Pacific Flight CX 104 Melbourne to Shangai",
+        "usedTransportMeans": {
+          "iD": "id:B-2398",
+          "name": "airbus A350"
+        },
+        "departureEvent": {
+          "departureDateTime": "2020-06-20T09:30:00Z"
+        }
+      },
+      "transportPackages": [
+        {
+          "iD": "gs1.org:sscc:59312345670002345",
+          "grossVolume": "0.55 m3",
+          "grossWeight": "450 Kg"
+        },
+        {
+          "iD": "gs1.org:sscc:59312345670002346",
+          "grossVolume": "0.55 m3",
+          "grossWeight": "450 Kg"
+        },
+        {
+          "iD": "gs1.org:sscc:59312345670002347",
+          "grossVolume": "0.55 m3",
+          "grossWeight": "450 Kg"
+        },
+        {
+          "iD": "gs1.org:sscc:59312345670002348",
+          "grossVolume": "0.55 m3",
+          "grossWeight": "450 Kg"
+        },
+        {
+          "iD": "gs1.org:sscc:59312345670002673",
+          "grossVolume": "0.58 m3",
+          "grossWeight": "465 Kg"
+        },
+        {
+          "iD": "gs1.org:sscc:59312345670002674",
+          "grossVolume": "0.58 m3",
+          "grossWeight": "465 Kg"
+        }
+      ],
+      "unloadingBaseportLocation": {
+        "iD": "id:CNPVG",
+        "name": "Shanghai Pudon International Apt"
       }
-    ],
-    "loadingBaseportLocation": {
-      "iD": "AUMEL",
-      "name": "Melbourne"
-    },
-    "mainCarriageTransportMovement": {
-      "iD": "iata.org:CX104",
-      "information": "Cathay Pacific Flight CX 104 Melbourne to Shangai",
-      "usedTransportMeans": {
-        "iD": "B-2398",
-        "name": "airbus A350"
-      },
-      "departureEvent":{
-         "departureDateTime":"2020-06-20T09:30Z"
-      }
-    },
-    "transportPackages": [
-      {
-        "iD": "gs1.org:sscc:59312345670002345",
-        "grossVolume": "0.55 m3",
-        "grossWeight": "450 Kg"
-      },
-      {
-        "iD": "gs1.org:sscc:59312345670002346",
-        "grossVolume": "0.55 m3",
-        "grossWeight": "450 Kg"
-      },
-      {
-        "iD": "gs1.org:sscc:59312345670002347",
-        "grossVolume": "0.55 m3",
-        "grossWeight": "450 Kg"
-      },
-      {
-        "iD": "gs1.org:sscc:59312345670002348",
-        "grossVolume": "0.55 m3",
-        "grossWeight": "450 Kg"
-      },
-      {
-        "iD": "gs1.org:sscc:59312345670002673",
-        "grossVolume": "0.58 m3",
-        "grossWeight": "465 Kg"
-      },
-      {
-        "iD": "gs1.org:sscc:59312345670002674",
-        "grossVolume": "0.58 m3",
-        "grossWeight": "465 Kg"
-      }
-    ],
-    "unloadingBaseportLocation": {
-      "iD": "CNPVG",
-      "name": "Shanghai Pudon International Apt"
     }
   }
 }

--- a/docs/certificates/CertificateOfOrigin.yml
+++ b/docs/certificates/CertificateOfOrigin.yml
@@ -18,7 +18,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/CertificateOfOrigin'
+                  $ref: '#/components/schemas/CertificateOfOriginObj'
                 type: array
     post:
       tags:
@@ -28,7 +28,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CertificateOfOrigin'
+              $ref: '#/components/schemas/CertificateOfOriginObj'
         description: ''
         required: true
       responses:
@@ -36,7 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CertificateOfOrigin'
+                $ref: '#/components/schemas/CertificateOfOriginObj'
           description: Created
   '/CertificatesOfOrigin/{id}':
     get:
@@ -56,7 +56,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CertificateOfOrigin'
+                $ref: '#/components/schemas/CertificateOfOriginObj'
     put:
       tags:
         - CertificatesOfOrigin
@@ -72,7 +72,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CertificateOfOrigin'
+              $ref: '#/components/schemas/CertificateOfOriginObj'
         description: ''
         required: true
       responses:
@@ -81,7 +81,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CertificateOfOrigin'
+                $ref: '#/components/schemas/CertificateOfOriginObj'
   '/CertificatesOfOrigin/{id}/Certification':
     post:
       tags:
@@ -110,6 +110,11 @@ paths:
           description: Created
 components:
   schemas:
+    CertificateOfOriginObj:
+      type: object
+      properties:
+        certificateOfOrigin:
+          $ref: '#/components/schemas/CertificateOfOrigin'
     CertificateOfOrigin:
       description: ''
       type: object


### PR DESCRIPTION
@onthebreeze, this is an alternative variant, where we refer to the schemas in API (needs to be deployed). This would allow us to re-use the components schemas instead of duplicating them, but would require to add a root property, in this case, `certificateOfOrigin`, see the updates for the Open API in json format.